### PR TITLE
Fix data races with parallel Conns

### DIFF
--- a/bulk-api.go
+++ b/bulk-api.go
@@ -115,7 +115,7 @@ func (c *Conn) StreamExecute(origSQL string, data <-chan []byte) error {
 			c.error("Retrying...")
 		}
 
-		proxy, err := NewProxy(c.Conf.Host, c.Conf.Port)
+		proxy, err := NewProxy(c.Conf.Host, c.Conf.Port, c.log)
 		if err != nil {
 			c.error(err)
 			lastErr = err
@@ -180,7 +180,7 @@ func (c *Conn) StreamQuery(origSQL string, data chan<- []byte) (int64, error) {
 			c.error("Retrying...")
 		}
 
-		proxy, err := NewProxy(c.Conf.Host, c.Conf.Port)
+		proxy, err := NewProxy(c.Conf.Host, c.Conf.Port, c.log)
 		if err != nil {
 			c.error(err)
 			lastErr = err

--- a/bulk-api.go
+++ b/bulk-api.go
@@ -64,7 +64,7 @@ func (c *Conn) BulkInsert(schema, table string, data *bytes.Buffer) (err error) 
 
 func (c *Conn) BulkExecute(sql string, data *bytes.Buffer) error {
 	if data == nil {
-		log.Fatal("You must pass in a bytes.Buffer pointer to BulkExecute")
+		c.log.Fatal("You must pass in a bytes.Buffer pointer to BulkExecute")
 	}
 	dataChan := make(chan []byte, 1)
 	dataChan <- data.Bytes()
@@ -79,7 +79,7 @@ func (c *Conn) BulkSelect(schema, table string, data *bytes.Buffer) (err error) 
 
 func (c *Conn) BulkQuery(sql string, data *bytes.Buffer) error {
 	if data == nil {
-		log.Fatal("You must pass in a bytes.Buffer pointer to BulkQuery")
+		c.log.Fatal("You must pass in a bytes.Buffer pointer to BulkQuery")
 	}
 	dataChan := make(chan []byte, 1)
 	go func() {
@@ -98,7 +98,7 @@ func (c *Conn) StreamInsert(schema, table string, data <-chan []byte) (err error
 
 func (c *Conn) StreamExecute(origSQL string, data <-chan []byte) error {
 	if data == nil {
-		log.Fatal("You must pass in a []byte chan to StreamExecute")
+		c.log.Fatal("You must pass in a []byte chan to StreamExecute")
 	}
 
 	sentData := false
@@ -130,7 +130,7 @@ func (c *Conn) StreamExecute(origSQL string, data <-chan []byte) error {
 			Command: "execute",
 			SQLtext: sql,
 		}
-		log.Info("EXA: Execute Import: ", sql)
+		c.log.Info("EXA: Execute Import: ", sql)
 		response, err := c.asyncSend(req)
 		if err != nil {
 			c.error("Unable to import bulk import data:", sql, err)
@@ -169,7 +169,7 @@ func (c *Conn) StreamSelect(schema, table string, data chan<- []byte) (int64, er
 
 func (c *Conn) StreamQuery(origSQL string, data chan<- []byte) (int64, error) {
 	if data == nil {
-		log.Fatal("You must pass in a []byte chan to StreamQuery")
+		c.log.Fatal("You must pass in a []byte chan to StreamQuery")
 	}
 
 	var bytesRead int64
@@ -195,7 +195,7 @@ func (c *Conn) StreamQuery(origSQL string, data chan<- []byte) (int64, error) {
 			Command: "execute",
 			SQLtext: sql,
 		}
-		log.Info("EXA: Execute Execute: ", sql)
+		c.log.Info("EXA: Execute Execute: ", sql)
 		response, err := c.asyncSend(req)
 		if err != nil {
 			c.error("Unable to bulk export data:", sql, err)

--- a/prep-stmt.go
+++ b/prep-stmt.go
@@ -50,7 +50,7 @@ func (c *Conn) getPrepStmt(schema, sql string) (*prepStmt, error) {
 	//      doesn't match the passed in data (i.e. placeholder/binds mismatch)
 	//      otherwise results in lowerlevel websocket closure
 
-	log.Info("EXA: Preparing stmt for:", sql)
+	c.log.Info("EXA: Preparing stmt for:", sql)
 	psc := c.prepStmtCache
 	ps := psc[sql]
 	if ps == nil {
@@ -100,12 +100,12 @@ func (c *Conn) createPrepStmt(schema string, sql string) (*prepStmt, error) {
 	sth := resp["statementHandle"].(float64)
 	paramData := resp["parameterData"].(map[string]interface{})
 	columnDefs := paramData["columns"].([]interface{})
-	log.Info("EXA: Got stmt handle ", sth)
+	c.log.Info("EXA: Got stmt handle ", sth)
 	return &prepStmt{sth, time.Now(), columnDefs}, nil
 }
 
 func (c *Conn) closePrepStmt(sth float64) {
-	log.Info("EXA: Closing stmt handle ", sth)
+	c.log.Info("EXA: Closing stmt handle ", sth)
 	closeReq := &closePrepStmtJSON{
 		Command:         "closePreparedStatement",
 		StatementHandle: int(sth),

--- a/proxy.go
+++ b/proxy.go
@@ -21,16 +21,21 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+
+	"github.com/op/go-logging"
 )
 
 type Proxy struct {
 	conn net.Conn
 	Host string
 	Port uint32
+	log  *logging.Logger
 }
 
 func NewProxy(host string, port uint16) (*Proxy, error) {
-	p := &Proxy{}
+	p := &Proxy{
+		log: logging.MustGetLogger("exasol"),
+	}
 
 	var err error
 	uri := fmt.Sprintf("%s:%d", host, port)
@@ -58,7 +63,7 @@ func NewProxy(host string, port uint16) (*Proxy, error) {
 
 	p.Port = binary.LittleEndian.Uint32(resp[4:])
 	p.Host = string(bytes.Trim(resp[8:], "\x00")) // Remove nulls
-	log.Debugf("EXA: Proxy is %s:%d", p.Host, p.Port)
+	p.log.Debugf("EXA: Proxy is %s:%d", p.Host, p.Port)
 
 	return p, nil
 }
@@ -71,7 +76,7 @@ func (p *Proxy) Read(data chan<- []byte) (int64, error) {
 			return 0, fmt.Errorf("Unable to read from proxy(1): %s", err)
 		}
 		// blank line means end of headers
-		log.Debug("Got header:", string(line))
+		p.log.Debug("Got header:", string(line))
 		if len(line) == 0 {
 			break
 		}
@@ -185,7 +190,7 @@ func (p *Proxy) sendHeaders(headers []string) error {
 	headers = append(headers, "")
 	for _, header := range headers {
 		header += "\r\n"
-		log.Debug("Sent Header: ", header)
+		p.log.Debug("Sent Header: ", header)
 		_, err := p.conn.Write([]byte(header))
 		if err != nil {
 			return fmt.Errorf("Unable to send header <%s>to proxy: %s", header, err)

--- a/proxy.go
+++ b/proxy.go
@@ -32,9 +32,11 @@ type Proxy struct {
 	log  *logging.Logger
 }
 
-func NewProxy(host string, port uint16) (*Proxy, error) {
+// NewProxy must never be used concurrently with the creating Conn.
+// Violating this rule will introduce data races into your program.
+func NewProxy(host string, port uint16, log *logging.Logger) (*Proxy, error) {
 	p := &Proxy{
-		log: logging.MustGetLogger("exasol"),
+		log: log,
 	}
 
 	var err error

--- a/utils.go
+++ b/utils.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/op/go-logging"
 )
 
 var keywordLock sync.RWMutex
@@ -75,7 +76,7 @@ func Transpose(matrix [][]interface{}) [][]interface{} {
 
 func (c *Conn) error(args ...interface{}) {
 	if c.Conf.SuppressError == false {
-		log.Error(args...)
+		c.log.Error(args...)
 	}
 }
 
@@ -91,14 +92,14 @@ func transposeToChan(ch chan<- []interface{}, matrix []interface{}) {
 }
 
 // For debugging
-func warnJson(msg interface{}) {
+func warnJson(l *logging.Logger, msg interface{}) {
 	json, _ := json.Marshal(msg)
-	log.Errorf("WARNING: %s", json)
+	l.Errorf("WARNING: %s", json)
 }
 
-func dieJson(msg interface{}) {
+func dieJson(l *logging.Logger, msg interface{}) {
 	json, _ := json.Marshal(msg)
-	log.Panicf("DIEING: %s", json)
+	l.Panicf("DIEING: %s", json)
 }
 
 func dump(i interface{}) {

--- a/websocket.go
+++ b/websocket.go
@@ -35,13 +35,13 @@ func (c *Conn) wsConnect() {
 		Scheme: "ws",
 		Host:   uri,
 	}
-	log.Debugf("EXA: connecting to %s", u.String())
+	c.log.Debugf("EXA: connecting to %s", u.String())
 	// According to documentation:
 	// > It is safe to call Dialer's methods concurrently.
 	ws, resp, err := defaultDialer.Dial(u.String(), nil)
 	if err != nil {
-		log.Debugf("resp:%s", resp)
-		log.Fatal("dial:", err)
+		c.log.Debugf("resp:%s", resp)
+		c.log.Fatal("dial:", err)
 	}
 	c.ws = ws
 }
@@ -67,7 +67,7 @@ func (c *Conn) asyncSend(request interface{}) (func() (map[string]interface{}, e
 		err = c.ws.ReadJSON(&response)
 
 		if err != nil {
-			log.Panicf("Error recving: %s", err)
+			c.log.Panicf("Error recving: %s", err)
 		} else if response["status"] != "ok" {
 			exception := response["exception"].(map[string]interface{})
 			err = errors.New(exception["text"].(string))

--- a/websocket.go
+++ b/websocket.go
@@ -20,6 +20,15 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+var (
+	defaultDialer = *websocket.DefaultDialer
+)
+
+func init() {
+	defaultDialer.Proxy = nil // TODO use proxy env
+	defaultDialer.EnableCompression = false
+}
+
 func (c *Conn) wsConnect() {
 	uri := fmt.Sprintf("%s:%d", c.Conf.Host, c.Conf.Port)
 	u := url.URL{
@@ -27,10 +36,9 @@ func (c *Conn) wsConnect() {
 		Host:   uri,
 	}
 	log.Debugf("EXA: connecting to %s", u.String())
-	dialer := websocket.DefaultDialer
-	dialer.Proxy = nil // TODO use proxy env
-	dialer.EnableCompression = false
-	ws, resp, err := dialer.Dial(u.String(), nil)
+	// According to documentation:
+	// > It is safe to call Dialer's methods concurrently.
+	ws, resp, err := defaultDialer.Dial(u.String(), nil)
 	if err != nil {
 		log.Debugf("resp:%s", resp)
 		log.Fatal("dial:", err)


### PR DESCRIPTION
Improve upon usage of Dialer and Logger so that common data races no longer occur.
Initial tests show that using parallel Conns is possible then.