### PR TITLE
Allow calling code to dissect Dial errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,7 +92,9 @@ func Connect(conf ConnConf) (*Conn, error) {
 
 	err := c.wsConnect()
 	if err != nil {
-		return nil, c.error("Unable to connect to Exasol: %s", err)
+		err = fmt.Errorf("unable to connect to Exasol: %w", err)
+		c.logUnsupressedError(err)
+		return nil, err
 	}
 
 	err = c.login()

--- a/utils.go
+++ b/utils.go
@@ -97,10 +97,16 @@ func Transpose(matrix [][]interface{}) [][]interface{} {
 
 func (c *Conn) error(str string, args ...interface{}) error {
 	err := fmt.Errorf(str, args...)
-	if c.Conf.SuppressError == false {
-		c.log.Error(err)
-	}
+	c.logUnsupressedError(err)
 	return err
+}
+
+func (c *Conn) logUnsupressedError(err error) {
+
+	if c.Conf.SuppressError {
+		return
+	}
+	c.log.Error(err)
 }
 
 func transposeToChan(ch chan<- []interface{}, matrix [][]interface{}) {


### PR DESCRIPTION
Errors from Dial calls are now getting wrapped.
Thus error chain is passed onto calling code.