### PR TITLE
Make NewDefaultWSHandler publicly usable

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,7 +111,7 @@ func Connect(conf ConnConf) (*Conn, error) {
 	}
 
 	if c.wsh == nil {
-		c.wsh = newDefaultWSHandler()
+		c.wsh = NewDefaultWSHandler()
 	}
 
 	err := c.wsConnect()

--- a/websocket_handler.go
+++ b/websocket_handler.go
@@ -27,7 +27,7 @@ type defWSHandler struct {
 	ws *websocket.Conn
 }
 
-func newDefaultWSHandler() *defWSHandler {
+func NewDefaultWSHandler() *defWSHandler {
 	return &defWSHandler{}
 }
 


### PR DESCRIPTION
Have a use-case where we first want to try to connect and if not fallback to our own implementation.